### PR TITLE
Dependencies fixed for scratch machine

### DIFF
--- a/linux-install.sh
+++ b/linux-install.sh
@@ -18,7 +18,9 @@ UPGRADE="upgrade"	# Package manager option to upgrade system
 pretty_name=""
 release_id=""
 
-DEPENDENCIES="build-essential git openjdk-7* tomcat7 tomcat7-admin tomcat7-common  mysql-server curl"
+DEPENDENCIES="build-essential git openjdk-7* tomcat7 tomcat7-admin tomcat7-common mysql-server curl unzip sudo curl"
+
+apt-get install sudo
 
 # Find out what system we're working with
 if [ -e /etc/os-release ]; then


### PR DESCRIPTION
I added some dependencies that were not met for a freshly installed Debian machine.
No sudo, no unzip, no curl and no Firefox (iceweasel on Debian not yet added).
